### PR TITLE
Fix Modal size on tablet

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostHelper.java
@@ -6,7 +6,6 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Point;
 import android.view.Display;
-import android.view.Surface;
 import android.view.WindowManager;
 
 import com.facebook.infer.annotation.Assertions;
@@ -18,12 +17,17 @@ import com.facebook.infer.annotation.Assertions;
 
   private static final Point MIN_POINT = new Point();
   private static final Point MAX_POINT = new Point();
+  private static final Point SIZE_POINT = new Point();
+  private static final Point REAL_SIZE_POINT = new Point();
 
   /**
    * To get the size of the screen, we use information from the WindowManager and
    * default Display. We don't use DisplayMetricsHolder, or Display#getSize() because
    * they return values that include the status bar. We only want the values of what
    * will actually be shown on screen.
+   * We use Display#getSize() to determine if the screen is in portrait or landscape.
+   * We don't use getRotation because the 'natural' rotation will be portrait on phones
+   * and landscape on tablets.
    * This should only be called on the native modules/shadow nodes thread.
    */
   @TargetApi(16)
@@ -32,14 +36,15 @@ import com.facebook.infer.annotation.Assertions;
     Display display = Assertions.assertNotNull(wm).getDefaultDisplay();
     // getCurrentSizeRange will return the min and max width and height that the window can be
     display.getCurrentSizeRange(MIN_POINT, MAX_POINT);
+    // getSize will return the dimensions of the screen in its current orientation
+    display.getSize(SIZE_POINT);
 
-    final int rotation = display.getRotation();
-    if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180) {
-      // If we are vertical the width value comes from min width and height comes from max height
-      return new Point(MIN_POINT.x, MAX_POINT.y);
+    if (SIZE_POINT.x < SIZE_POINT.y) {
+     // If we are vertical the width value comes from min width and height comes from max height
+     return new Point(MIN_POINT.x, MAX_POINT.y);
     } else {
-      // If we are horizontal the width value comes from max width and height comes from min height
-      return new Point(MAX_POINT.x, MIN_POINT.y);
+     // If we are horizontal the width value comes from max width and height comes from min height
+     return new Point(MAX_POINT.x, MIN_POINT.y);
     }
   }
 }


### PR DESCRIPTION
On tablets, using Display.getRotation() returned ROTATION_0 or ROTATION_180 when it was in landscape, not portrait as it does on phones. This resulted in the Modal being sized incorrectly on tablets. Using size and comparing width and height is the only way I can think of to figure out the device orientation and give the modal the correct size. With this change, all issues listed in #7708 should be resolved.

**Test plan**
Modal should correctly fill screen on phone and tablet in both portrait and landscape.